### PR TITLE
feat: fail if error when retrieving AssumeRoleWithWebIdentity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - '/'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      time: '22:00'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test
+
+  plugin-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make plugin-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM buildkite/plugin-tester:v4.1.1
+
+# Create non-root user
+RUN adduser --disabled-password --gecos "" plugin-tester
+USER plugin-tester

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+all: test plugin-lint integration-test
+
+.PHONY: test
+test:
+	@docker compose run --rm test
+
+.PHONY: plugin-lint
+plugin-lint:
+	@docker compose run plugin-lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  plugin-lint:
+    image: buildkite/plugin-linter:v2.1.0
+    command: ['--id', 'elastic/oblt-aws-auth']
+    volumes:
+      - ".:/plugin:ro"
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ".:/plugin:ro"
+    command: ['bats', 'tests/unit']

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,8 +19,15 @@ response=$(curl \
   "https://sts.amazonaws.com?Action=AssumeRoleWithWebIdentity&RoleArn=${aws_role_arn}&RoleSessionName=${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_NUMBER}&DurationSeconds=${duration_seconds}&WebIdentityToken=${oidc_token}&Version=2011-06-15")
 
 credentials_json_path=".AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials"
-AWS_ACCESS_KEY_ID=$(echo "$response" | jq -r "${credentials_json_path}.AccessKeyId")
-AWS_SECRET_ACCESS_KEY=$(echo "$response" | jq -r "${credentials_json_path}.SecretAccessKey")
-AWS_SESSION_TOKEN=$(echo "$response" | jq -r "${credentials_json_path}.SessionToken")
+AWS_ACCESS_KEY_ID=$(echo "$response" | jq -r "${credentials_json_path}.AccessKeyId // \"\"")
+AWS_SECRET_ACCESS_KEY=$(echo "$response" | jq -r "${credentials_json_path}.SecretAccessKey // \"\"")
+AWS_SESSION_TOKEN=$(echo "$response" | jq -r "${credentials_json_path}.SessionToken // \"\"")
+
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_SESSION_TOKEN" ]; then
+  echo "^^^ +++"
+  echo "Failed to assume AWS role:"
+  echo "${response}"
+  exit 1
+fi
 
 export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN

--- a/tests/fixtures/errors.json
+++ b/tests/fixtures/errors.json
@@ -1,0 +1,1 @@
+{"Error":{"Code":"ValidationError","Message":"The requested DurationSeconds exceeds the MaxSessionDuration set for this role.","Type":"Sender"},"RequestId":"55d19478-82d4-4aaa-8e61-ed931344b6cc"}

--- a/tests/fixtures/success.json
+++ b/tests/fixtures/success.json
@@ -1,0 +1,24 @@
+{
+  "AssumeRoleWithWebIdentityResponse": {
+    "AssumeRoleWithWebIdentityResult": {
+        "SubjectFromWebIdentityToken": "amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A",
+        "Audience": "client.5498841531868486423.1548@apps.example.com/Audience",
+        "AssumedRoleUser": {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1",
+            "AssumedRoleId": "AROACLKWSDQRAOEXAMPLE:app1/AssumedRoleId"
+        },
+        "Credentials": {
+            "SessionToken": "AQoDYXdzEE0a8ANXXXXXXXXNO1ewxE5TijQyp+IEXAMPLE/SessionToken", 
+            "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY/SecretAccessKey", 
+            "Expiration": "2014-10-24T23:00:23Z/Expiration",
+            "AccessKeyId": "ASgeIAIOSFODNN7EXAMPLE/AccessKeyId"
+        },
+        "SourceIdentity": "SourceIdentityValue/SourceIdentity",
+        "Provider": "www.amazon.com/Provider"
+    },
+    "ResponseMetadata": {
+        "RequestId": "ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE"
+    }
+  }
+}
+ 

--- a/tests/unit/asset.bats
+++ b/tests/unit/asset.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+    load "${BATS_PLUGIN_PATH}/load.bash"
+
+    export BUILDKITE_REPO="elastic/repo"
+    export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+    export BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_WITH_WEB_IDENTITY_ROLE_ARN="role123"
+}
+
+@test "failure to get token" {
+    # arrange
+    stub buildkite-agent "oidc request-token --audience sts.amazonaws.com * : echo 'buildkite-oidc-token'"
+    stub curl "cat $PWD/tests/fixtures/errors.json"
+
+    # act
+    run $PWD/hooks/pre-command
+
+    # assert
+    assert_failure
+}


### PR DESCRIPTION
Fixes when AssumeRoleWithWebIdentity failed.

We have found some errors when using a different duration time:

> {"Error":{"Code":"ValidationError","Message":"The requested DurationSeconds exceeds the MaxSessionDuration set for this role.","Type":"Sender"},"RequestId":"55d19478-82d4-4aaa-8e61-ed931344b6cc"}


In addition, I added some Unit Tests, dependabot and GH actions


### Test

See this [Buildkite build](https://buildkite.com/elastic/integrations/builds/25723#0196aff8-f9bb-4445-916b-1974b01681aa/106-112) when duration is > than max

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/422defb8-6ca2-495e-b3b9-aa4f36a2a3db" />


See this [Buildkite build](https://buildkite.com/elastic/integrations/builds/25723#0196affc-afc6-45b0-84b7-d4b323c17065/106) when duration is < than max.

<img width="885" alt="image" src="https://github.com/user-attachments/assets/589443c3-2eab-48cb-a90e-3fa5adef3ecd" />
