### PR TITLE
Add release automation with release-drafter

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,35 @@
+- name: "changelog:breaking"
+  color: "d73a4a"
+  description: "When a breaking change is introduced"
+
+- name: "changelog:feature"
+  color: "0075ca"
+  description: "When a new feature is introduced"
+
+- name: "changelog:enhancement"
+  color: "a2eeef"
+  description: "When an existing feature is improved"
+
+- name: "changelog:fix"
+  color: "e4e669"
+  description: "When a bug is fixed"
+
+- name: "changelog:docs"
+  color: "0075ca"
+  description: "When documentation is updated"
+
+- name: "changelog:chore"
+  color: "e4e669"
+  description: "When a chore is done"
+
+- name: "changelog:ci"
+  color: "e4e669"
+  description: "When CI is updated"
+
+- name: "changelog:dependencies"
+  color: "0075ca"
+  description: "When dependencies are updated"
+
+- name: "changelog:skip"
+  color: "ffffff"
+  description: "When a PR should be excluded from the changelog"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,38 @@
+# https://github.com/release-drafter/release-drafter?tab=readme-ov-file#configuration-options
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+name-template: 'oblt-aws-auth-buildkite-plugin v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+category-template: '### $TITLE'
+categories:
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'changelog:breaking' # When a breaking change is introduced
+  - title: '✨ Features'
+    labels:
+      - 'changelog:feature' # When a new feature is introduced
+      - 'changelog:enhancement' # When an existing feature is improved
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'changelog:fix' # When a bug is fixed
+  - title: '📝 Documentation'
+    labels:
+      - 'changelog:docs' # When documentation is updated
+  - title: '🧰 Maintenance'
+    labels:
+      - 'changelog:chore' # When a chore is done
+      - 'changelog:ci' # When CI is updated
+      - 'changelog:dependencies' # When dependencies are updated
+exclude-labels:
+  - 'changelog:skip' # When a PR should be excluded from the changelog
+version-resolver:
+  major:
+    labels:
+      - 'changelog:breaking'
+  minor:
+    labels:
+      - 'changelog:feature'
+  default: patch

--- a/.github/workflows/bump-readme-version.yml
+++ b/.github/workflows/bump-readme-version.yml
@@ -1,4 +1,4 @@
-name: bump-version
+name: bump-readme-version
 
 on:
   release:
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  bump-version:
+  bump:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,42 @@
+name: bump-version
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Get new version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+      - name: Update version in README
+        run: |
+          sed -i "s|elastic/oblt-aws-auth#v[0-9]*\.[0-9]*\.[0-9]*|elastic/oblt-aws-auth#${VERSION}|g" README.md
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git diff --quiet && echo "No changes to commit" && exit 0
+          BRANCH="update-version-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add README.md
+          git commit -m "docs: bump version to ${VERSION} in README"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --title "docs: bump version to ${VERSION} in README" \
+            --body "Update plugin version reference in README to ${VERSION}." \
+            --base main \
+            --head "${BRANCH}"

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,25 @@
+name: labels-sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+  workflow_dispatch: ~
+
+permissions:
+  contents: read
+
+jobs:
+  sync-labels:
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-slim
+    steps:
+      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,36 @@
+name: required-labels
+
+on:
+  merge_group: ~
+  workflow_dispatch: ~
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  check-labels:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - id: get-labels
+        run: |
+          labels=$(yq '[.categories[].labels] + .exclude-labels | flatten | unique | sort | @tsv' .github/release-drafter.yml | tr '\t' ',')
+          echo "labels=$labels" >> "${GITHUB_OUTPUT}"
+
+      - id: check-labels
+        uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 # v5.5.1
+        with:
+          mode: exactly
+          count: 1
+          use_regex: false
+          add_comment: false
+          labels: ${{ steps.get-labels.outputs.labels }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -27,7 +27,7 @@ Every PR must have exactly one `changelog:*` label. When merged to `main`, relea
 
 ### 3. Review the version bump PR
 
-After publishing, the [bump-version workflow](../.github/workflows/bump-version.yml) automatically creates a PR to update the plugin version in README.md. Review and merge it to keep the documentation up to date.
+After publishing, the [bump-readme-version workflow](../.github/workflows/bump-readme=version.yml) automatically creates a PR to update the plugin version in README.md. Review and merge it to keep the documentation up to date.
 
 ## Changelog Labels
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,46 @@
+# Release Process
+
+This document outlines how to release a new version of this plugin.
+
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/). The version is automatically determined by [release-drafter](https://github.com/release-drafter/release-drafter) based on PR labels:
+
+- `changelog:breaking` → Major version bump (e.g., 1.0.0 → 2.0.0)
+- `changelog:feature` → Minor version bump (e.g., 1.0.0 → 1.1.0)
+- Other labels → Patch version bump (e.g., 1.0.0 → 1.0.1)
+
+See [release-drafter.yml](../.github/release-drafter.yml) for configuration details.
+
+## How to Release
+
+### 1. Merge PRs with changelog labels
+
+Every PR must have exactly one `changelog:*` label. When merged to `main`, release-drafter automatically updates the draft release.
+
+### 2. Publish the draft release
+
+1. Go to [Releases](../../releases)
+2. Wait for the [release-drafter workflow](../.github/workflows/release-drafter.yml) to finish
+3. Review the draft release notes
+4. Click **Publish release**
+
+### 3. Review the version bump PR
+
+After publishing, the [bump-version workflow](../.github/workflows/bump-version.yml) automatically creates a PR to update the plugin version in README.md. Review and merge it to keep the documentation up to date.
+
+## Changelog Labels
+
+Every PR needs exactly one of these labels:
+
+| Label | Description | Version Impact |
+|-------|-------------|----------------|
+| `changelog:breaking` | Breaking changes | Major |
+| `changelog:feature` | New features | Minor |
+| `changelog:enhancement` | Improvements to existing features | Patch |
+| `changelog:fix` | Bug fixes | Patch |
+| `changelog:docs` | Documentation updates | Patch |
+| `changelog:chore` | Maintenance tasks | Patch |
+| `changelog:ci` | CI/CD changes | Patch |
+| `changelog:dependencies` | Dependency updates | Patch |
+| `changelog:skip` | Excluded from changelog | None |


### PR DESCRIPTION
## Summary

This PR adds comprehensive release automation using release-drafter and label synchronization.

## Changes

- **`.github/release-drafter.yml`** - Release drafter configuration with changelog categories and semantic versioning rules
- **`.github/labels.yml`** - Defines all changelog labels (breaking, feature, enhancement, fix, docs, chore, ci, dependencies, skip)
- **`.github/workflows/labels-sync.yml`** - Automatically syncs labels from config to GitHub repository
- **`.github/workflows/required-labels.yml`** - Enforces that every PR has exactly one changelog label
- **`.github/workflows/release-drafter.yml`** - Auto-drafts releases with categorized changelogs on merge to main
- **`.github/workflows/bump-version.yml`** - Creates a PR to update README version after release is published

## Features

✅ **Automatic label synchronization** - Labels are defined in `.github/labels.yml` and synced to the repository  
✅ **Required changelog labels** - Every PR must have exactly one changelog label before merging  
✅ **Automatic release drafts** - Releases are auto-drafted with categorized changes when PRs merge to main  
✅ **Semantic versioning** - Version auto-increments based on PR labels (breaking = major, feature = minor, others = patch)  
✅ **Automated version bumps** - After publishing a release, a PR is created to update the plugin version in README.md  

## Changelog Labels

- `changelog:breaking` - Breaking changes (triggers major version bump)
- `changelog:feature` - New features (triggers minor version bump)
- `changelog:enhancement` - Improvements to existing features
- `changelog:fix` - Bug fixes
- `changelog:docs` - Documentation updates
- `changelog:chore` - Maintenance tasks
- `changelog:ci` - CI/CD changes
- `changelog:dependencies` - Dependency updates
- `changelog:skip` - Exclude from changelog

## References

Based on patterns from:
- https://github.com/elastic/oblt-actions